### PR TITLE
fix: error code if execv() fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
            cmake -S. -Bbuild -DBUILD_TESTING=OFF
            cd build
            make
-           ./subarch-select sse2 echo -- success
+           ./subarch-select sse2 /usr/bin/echo -- success

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
-#include "cpuinfo_x86.h"
+#include <cpuinfo_x86.h>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <unistd.h>
@@ -146,7 +147,9 @@ int main(int argc, char** argv) {
             ss << " " << argv[j];
         }
         log("executing: " + path + ss.str());
-        execv(path.c_str(), argv+i-1);
+        int error = execv(path.c_str(), argv+i-1);
+        std::cerr << strerror(errno) << "\n";
+        return 1;
     } else {
         return 1;
     }


### PR DESCRIPTION
if execv() fails, subarch-select now return '1' as a return value and prints an error message to cerr.